### PR TITLE
Fixed menu and logging

### DIFF
--- a/scripts/scaffold.js
+++ b/scripts/scaffold.js
@@ -18,21 +18,20 @@ module.exports = function scaffold (options) {
       message: 'Project configuration: ',
       choices: [
         new inquirer.Separator(),
-        'Default',
+        'Create project',
         new inquirer.Separator(),
         'Change view: (' + currentView + ')',
         'Change model: (' + currentModel + ')',
-        'Change modules: (' + currentModules + ')',
-        'Done'
+        'Change modules: (' + currentModules + ')'
       ]
     }])
     .then(function (answers) {
+      if (answers.main.indexOf('Create project') === 0 || answers.main.indexOf('Default') === 0) {
+        scaffold()
+      }
       if (answers.main.indexOf('Change view') === 0) { view() }
       if (answers.main.indexOf('Change model') === 0) { model() }
       if (answers.main.indexOf('Change modules') === 0) { modules() }
-      if (answers.main.indexOf('Done') === 0 || answers.main.indexOf('Default') === 0) {
-        scaffold()
-      }
     })
   }
 
@@ -124,7 +123,6 @@ module.exports = function scaffold (options) {
 
     fs.copySync(`${cliDirectory}/scaffold/${currentView.toLowerCase()}/webpack.config.js`, `${CWD}/${appName}/webpack.config.js`)
     fs.copySync(`${cliDirectory}/scaffold/${currentView.toLowerCase()}/package.json`, `${CWD}/${appName}/package.json`)
-    fs.copySync(`${cliDirectory}/scaffold/${currentView.toLowerCase()}/build`, `${CWD}/${appName}/build`)
 
     fs.copySync(`${cliDirectory}/scaffold/shared/index.html`, `${CWD}/${appName}/index.html`)
     fs.copySync(`${cliDirectory}/scaffold/shared`, `${CWD}/${appName}/src`)
@@ -165,7 +163,10 @@ module.exports = function scaffold (options) {
       npm.on('close', function (code) {
         console.log('* All npm packages successfully installed!')
         console.log(`\n---------------------------------------------------------------------------`)
-        console.log(`\n* SUCCESS: New application '${appName}' created at '${CWD}'.\n`)
+        console.log(`\n* SUCCESS: New application '${appName}' created at '${CWD}'`)
+        console.log('\n1. Go to project directory')
+        console.log('\n2. Run \'npm start\'')
+        console.log('\n3. Go to \'localhost:3000\' in your browser')
       })
     })
 


### PR DESCRIPTION
### Menu

No need to have both "default" and "done". The concept of "default" here are the preselected view, model and modules. So only need "done", which I renamed to "Create project"
### Build

It tried to copy a build folder from the CLI, but folder is created by webpack then running `npm run build`, so removed that.. it failed on my machine
### Logging

Added some extra logging on what to do after everything is installed
### Autostart

Would be cool to actually enter the folder, run npm start and fire up the browser as well... but yeah, dunno how to do that.

Awesome stuff! Looks great :-D
